### PR TITLE
support `swr/mutation` & add e2e tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,4 +19,6 @@ jobs:
           node-version: 16
           cache: 'pnpm'
       - run: pnpm install
+      - name: Install Playwright
+        run: pnpx playwright install --with-deps
       - run: pnpm test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,4 @@ jobs:
           node-version: 16
           cache: 'pnpm'
       - run: pnpm install
-      - name: Install Playwright
-        run: pnpx playwright install --with-deps
       - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
-  "name": "next-swr-endpoints",
+  "name": "next-swr-endpoints-monorepo",
   "private": true,
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "test": "turbo run test",
     "build": "turbo run build"
   },
-  "packageManager": "pnpm@7",
+  "packageManager": "pnpm@7.3.0",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/packages/example-app/README.md
+++ b/packages/example-app/README.md
@@ -1,0 +1,6 @@
+# An example app.
+
+### End-to-end testing
+
+This project is using Playwright to run browser tests. In order to run the tests, run `pnpm test`.
+To run against a development build, you can run `env BASE_URL=http://localhost:3002 pnpm test`

--- a/packages/example-app/next.config.js
+++ b/packages/example-app/next.config.js
@@ -1,39 +1,3 @@
-// /**
-//  * @param {import('next').NextConfig} given
-//  * @returns {import('next').NextConfig}
-//  */
-// function withSwrApiEndpoints(given = {}) {
-//   return {
-//     ...given,
-//     webpack(config, context) {
-//       config.module.rules.unshift({
-//         test: /\.api\./,
-//         issuerLayer: "api",
-//         use: [
-//           require.resolve("next-swr-endpoints/dist/swr-server-endpoint-loader"),
-//           context.defaultLoaders.babel,
-//         ],
-//       });
-//       config.module.rules.unshift({
-//         test: /\.api\./,
-//         use: [
-//           require.resolve("next-swr-endpoints/dist/swr-client-endpoint-loader"),
-//           context.defaultLoaders.babel,
-//         ],
-//       });
-//       return given.webpack ? given.webpack(config, context) : config;
-//     },
-//     pageExtensions: (
-//       given.pageExtensions ?? ["js", "jsx", "ts", "tsx"]
-//     ).flatMap((value) => {
-//       return [value, `api.${value}`];
-//     }),
-//   };
-// }
-
-// const config = withSwrApiEndpoints();
-// module.exports = config;
-
 const { withSwrApiEndpoints } = require("next-swr-endpoints");
 
 module.exports = withSwrApiEndpoints();

--- a/packages/example-app/package.json
+++ b/packages/example-app/package.json
@@ -7,20 +7,21 @@
     "build": "next build",
     "start": "next start",
     "dev": "next dev",
-    "test": "#"
+    "test": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "^12.1.6",
-    "next-swr-endpoints": "workspace:^1.0.0",
+    "next-swr-endpoints": "workspace:*",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "swr": "^1.3.0",
+    "swr": "^2.0.0-beta.6",
     "zod": "^3.17.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.23.2",
     "@types/node": "^17.0.38",
     "@types/react": "^18.0.10",
     "@types/react-dom": "^18.0.5",

--- a/packages/example-app/package.json
+++ b/packages/example-app/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "dev": "next dev --port=3002",
+    "prepare-env:test": "playwright install --with-deps",
     "test": "playwright test"
   },
   "keywords": [],

--- a/packages/example-app/package.json
+++ b/packages/example-app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build",
     "start": "next start",
-    "dev": "next dev",
+    "dev": "next dev --port=3002",
     "test": "playwright test"
   },
   "keywords": [],

--- a/packages/example-app/pages/api/people.swr.ts
+++ b/packages/example-app/pages/api/people.swr.ts
@@ -1,9 +1,16 @@
 import z from "zod";
-import { query } from "next-swr-endpoints";
+import { query, mutation } from "next-swr-endpoints";
 
 export const useAllPeople = query(
   z.object({ name: z.string() }),
   async (user) => {
     return `Hello, ${user.name} :D`;
+  }
+);
+
+export const useListPeopleWith = mutation(
+  z.object({ name: z.string() }),
+  async ({ name }) => {
+    return ["John", "Jane", "Bob", "Alice", name.trim()];
   }
 );

--- a/packages/example-app/pages/form.tsx
+++ b/packages/example-app/pages/form.tsx
@@ -1,0 +1,36 @@
+import { useListPeopleWith } from "./api/people.swr";
+
+export default function Page() {
+  const listPeopleWith = useListPeopleWith();
+
+  return (
+    <div>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          const name = new FormData(event.currentTarget).get("name");
+          if (!name) throw new Error("can't get name");
+          listPeopleWith.trigger({ name: String(name) });
+        }}
+      >
+        <label>
+          Name: <input type="text" name="name" placeholder="Enter a name..." />
+        </label>
+        <button type="submit" tabIndex={0}>
+          Submit
+        </button>
+      </form>
+      {!listPeopleWith.data ? (
+        <p id="result">
+          No data, {listPeopleWith.isMutating ? "mutating" : "idle"}.
+        </p>
+      ) : (
+        <ul id="result">
+          {listPeopleWith.data.map((name) => {
+            return <li key={name}>{name}</li>;
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/example-app/pages/index.tsx
+++ b/packages/example-app/pages/index.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   const result = useAllPeople({ name: "gal" });
 
   return (
-    <div>
+    <div id="result">
       {result.data
         ? result.data
         : result.error

--- a/packages/example-app/pages/index.tsx
+++ b/packages/example-app/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useAllPeople } from "./api/people.swr";
+import useSWRMutation from "swr/mutation";
 
 export default function Home() {
   const result = useAllPeople({ name: "gal" });

--- a/packages/example-app/playwright.config.ts
+++ b/packages/example-app/playwright.config.ts
@@ -1,11 +1,20 @@
 import { type PlaywrightTestConfig, devices } from "@playwright/test";
 
+const baseURL = process.env.BASE_URL || `http://localhost:9999`;
+
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   testDir: "tests/e2e",
+  ...(!process.env.BASE_URL && {
+    webServer: {
+      command: "pnpm run start --port=9999",
+      url: "http://localhost:9999",
+    },
+  }),
   use: {
     trace: "on-first-retry",
+    baseURL,
   },
   projects: [
     {

--- a/packages/example-app/playwright.config.ts
+++ b/packages/example-app/playwright.config.ts
@@ -1,0 +1,18 @@
+import { type PlaywrightTestConfig, devices } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  testDir: "tests/e2e",
+  use: {
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+};
+
+export default config;

--- a/packages/example-app/tests/e2e/mutation.spec.ts
+++ b/packages/example-app/tests/e2e/mutation.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test("mutation", async ({ page }) => {
+  await page.goto("/form");
+  const title = page.locator("#result");
+  await expect(title).toHaveText("No data, idle.");
+
+  const input = page.locator(`input[type="text"]`);
+  await input.type("Gal");
+  await input.press("Enter");
+
+  await expect(title.locator("li:last-child")).toHaveText("Gal");
+});

--- a/packages/example-app/tests/e2e/query.spec.ts
+++ b/packages/example-app/tests/e2e/query.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("basic test", async ({ page }) => {
+  await page.goto("http://localhost:3002");
+  const title = page.locator("#result");
+  await expect(title).toHaveText("Hello, gal :D");
+});

--- a/packages/example-app/tests/e2e/query.spec.ts
+++ b/packages/example-app/tests/e2e/query.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 test("basic test", async ({ page }) => {
-  await page.goto("http://localhost:3002");
+  await page.goto("/");
   const title = page.locator("#result");
   await expect(title).toHaveText("Hello, gal :D");
 });

--- a/packages/next-swr-endpoints/package.json
+++ b/packages/next-swr-endpoints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-swr-endpoints",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "swr": "^1.3.0",
+    "swr": "^2.0.0-beta.6",
     "tsup": "^6.0.1",
     "typescript": "^4.7.2"
   },

--- a/packages/next-swr-endpoints/src/index.ts
+++ b/packages/next-swr-endpoints/src/index.ts
@@ -1,4 +1,5 @@
 import type { SWRResponse } from "swr";
+import type { SWRMutationResponse } from "swr/mutation";
 import type { NextConfig } from "next";
 
 type Parser<Into> =
@@ -9,6 +10,13 @@ export function query<T, V>(
   parser: Parser<T>,
   callback: (parsed: T) => Promise<V>
 ): (v: T) => SWRResponse<V> {
+  throw new Error("This code path should not be reached");
+}
+
+export function mutation<T, V>(
+  parser: Parser<T>,
+  callback: (parsed: T) => Promise<V>
+): SWRMutationResponse<V, any, T> {
   throw new Error("This code path should not be reached");
 }
 
@@ -29,19 +37,18 @@ export function withSwrApiEndpoints(given: NextConfig = {}): NextConfig {
   return {
     ...given,
     webpack(config, context) {
+      const serverLoader = require.resolve("./swr-server-endpoint-loader");
+      const pageLoader = require.resolve("./swr-client-endpoint-loader");
       config.module.rules.unshift({
         test: testRegex,
         issuerLayer: "api",
-        use: [
-          require.resolve("./swr-server-endpoint-loader"),
-          context.defaultLoaders.babel,
-        ],
+        use: [serverLoader, context.defaultLoaders.babel],
       });
       config.module.rules.unshift({
         test: testRegex,
         use: [
           {
-            loader: require.resolve("./swr-client-endpoint-loader"),
+            loader: pageLoader,
             options: {
               projectDir: context.dir,
               pageExtensionsRegex: testRegex,

--- a/packages/next-swr-endpoints/src/index.ts
+++ b/packages/next-swr-endpoints/src/index.ts
@@ -1,5 +1,4 @@
 import type { SWRResponse } from "swr";
-import type { SWRMutationResponse } from "swr/mutation";
 import type { NextConfig } from "next";
 
 type Parser<Into> =
@@ -10,13 +9,6 @@ export function query<T, V>(
   parser: Parser<T>,
   callback: (parsed: T) => Promise<V>
 ): (v: T) => SWRResponse<V> {
-  throw new Error("This code path should not be reached");
-}
-
-export function mutation<T, V>(
-  parser: Parser<T>,
-  callback: (parsed: T) => Promise<V>
-): SWRMutationResponse<V, any, T> {
   throw new Error("This code path should not be reached");
 }
 
@@ -37,19 +29,19 @@ export function withSwrApiEndpoints(given: NextConfig = {}): NextConfig {
   return {
     ...given,
     webpack(config, context) {
-      const serverLoader = require.resolve("./swr-server-endpoint-loader");
-      const pageLoader = require.resolve("./swr-client-endpoint-loader");
-      console.log({ serverLoader, pageLoader });
       config.module.rules.unshift({
         test: testRegex,
         issuerLayer: "api",
-        use: [serverLoader, context.defaultLoaders.babel],
+        use: [
+          require.resolve("./swr-server-endpoint-loader"),
+          context.defaultLoaders.babel,
+        ],
       });
       config.module.rules.unshift({
         test: testRegex,
         use: [
           {
-            loader: pageLoader,
+            loader: require.resolve("./swr-client-endpoint-loader"),
             options: {
               projectDir: context.dir,
               pageExtensionsRegex: testRegex,

--- a/packages/next-swr-endpoints/src/index.ts
+++ b/packages/next-swr-endpoints/src/index.ts
@@ -1,4 +1,5 @@
 import type { SWRResponse } from "swr";
+import type { SWRMutationResponse } from "swr/mutation";
 import type { NextConfig } from "next";
 
 type Parser<Into> =
@@ -9,6 +10,13 @@ export function query<T, V>(
   parser: Parser<T>,
   callback: (parsed: T) => Promise<V>
 ): (v: T) => SWRResponse<V> {
+  throw new Error("This code path should not be reached");
+}
+
+export function mutation<T, V>(
+  parser: Parser<T>,
+  callback: (parsed: T) => Promise<V>
+): SWRMutationResponse<V, any, T> {
   throw new Error("This code path should not be reached");
 }
 
@@ -29,19 +37,19 @@ export function withSwrApiEndpoints(given: NextConfig = {}): NextConfig {
   return {
     ...given,
     webpack(config, context) {
+      const serverLoader = require.resolve("./swr-server-endpoint-loader");
+      const pageLoader = require.resolve("./swr-client-endpoint-loader");
+      console.log({ serverLoader, pageLoader });
       config.module.rules.unshift({
         test: testRegex,
         issuerLayer: "api",
-        use: [
-          require.resolve("./swr-server-endpoint-loader"),
-          context.defaultLoaders.babel,
-        ],
+        use: [serverLoader, context.defaultLoaders.babel],
       });
       config.module.rules.unshift({
         test: testRegex,
         use: [
           {
-            loader: require.resolve("./swr-client-endpoint-loader"),
+            loader: pageLoader,
             options: {
               projectDir: context.dir,
               pageExtensionsRegex: testRegex,

--- a/packages/next-swr-endpoints/src/index.ts
+++ b/packages/next-swr-endpoints/src/index.ts
@@ -16,7 +16,7 @@ export function query<T, V>(
 export function mutation<T, V>(
   parser: Parser<T>,
   callback: (parsed: T) => Promise<V>
-): SWRMutationResponse<V, any, T> {
+): () => SWRMutationResponse<V, any, T> {
   throw new Error("This code path should not be reached");
 }
 

--- a/packages/next-swr-endpoints/src/parseEndpointFile.ts
+++ b/packages/next-swr-endpoints/src/parseEndpointFile.ts
@@ -1,35 +1,29 @@
 import { parse } from "acorn";
 import { simple } from "acorn-walk";
 
-export type ParsedQuery = {
+type ParsedQuery = {
   parserCode: string;
   callbackCode: string;
 };
-export type Queries = { [name: string]: ParsedQuery };
+type Queries = { [name: string]: ParsedQuery };
 export function parseEndpointFile(content: string): {
   queries: Queries;
-  mutations: Queries;
   regionsToRemove: [start: number, end: number][];
 } {
   const ast = parse(content, { ecmaVersion: "latest", sourceType: "module" });
   const errors: string[] = [];
   const queries: Queries = {};
-  const mutations: Queries = {};
   const regionsToRemove: [start: number, end: number][] = [];
   simple(ast, {
     ExportNamedDeclaration(node: any) {
       for (const declaration of node.declaration.declarations) {
-        const calleeName = declaration.init?.calle?.name;
         if (
           declaration.init.type === "CallExpression" &&
-          ["query", "mutation"].includes(calleeName)
+          declaration.init.callee?.name === "query"
         ) {
           const name = declaration.id;
           const [parser, callback] = declaration.init.arguments;
-
-          const bag = calleeName === "query" ? queries : mutations;
-
-          bag[content.slice(name.start, name.end)] = {
+          queries[content.slice(name.start, name.end)] = {
             parserCode: content.slice(parser.start, parser.end),
             callbackCode: content.slice(callback.start, callback.end),
           };
@@ -48,5 +42,5 @@ export function parseEndpointFile(content: string): {
     throw new Error(errors.join("\n"));
   }
 
-  return { queries, mutations, regionsToRemove };
+  return { queries, regionsToRemove };
 }

--- a/packages/next-swr-endpoints/src/parseEndpointFile.ts
+++ b/packages/next-swr-endpoints/src/parseEndpointFile.ts
@@ -5,25 +5,29 @@ type ParsedQuery = {
   parserCode: string;
   callbackCode: string;
 };
-type Queries = { [name: string]: ParsedQuery };
+export type Queries = { [name: string]: ParsedQuery };
 export function parseEndpointFile(content: string): {
   queries: Queries;
+  mutations: Queries;
   regionsToRemove: [start: number, end: number][];
 } {
   const ast = parse(content, { ecmaVersion: "latest", sourceType: "module" });
   const errors: string[] = [];
   const queries: Queries = {};
+  const mutations: Queries = {};
   const regionsToRemove: [start: number, end: number][] = [];
   simple(ast, {
     ExportNamedDeclaration(node: any) {
       for (const declaration of node.declaration.declarations) {
         if (
           declaration.init.type === "CallExpression" &&
-          declaration.init.callee?.name === "query"
+          ["query", "mutation"].includes(declaration.init.callee?.name)
         ) {
           const name = declaration.id;
           const [parser, callback] = declaration.init.arguments;
-          queries[content.slice(name.start, name.end)] = {
+          const bag =
+            "query" === declaration.init.callee.name ? queries : mutations;
+          bag[content.slice(name.start, name.end)] = {
             parserCode: content.slice(parser.start, parser.end),
             callbackCode: content.slice(callback.start, callback.end),
           };
@@ -42,5 +46,5 @@ export function parseEndpointFile(content: string): {
     throw new Error(errors.join("\n"));
   }
 
-  return { queries, regionsToRemove };
+  return { queries, regionsToRemove, mutations };
 }

--- a/packages/next-swr-endpoints/src/swr-client-endpoint-loader.ts
+++ b/packages/next-swr-endpoints/src/swr-client-endpoint-loader.ts
@@ -34,26 +34,69 @@ const loader: LoaderDefinition<{
     .replace(pageExtensionsRegex, "");
   const apiPage = `${basePath}/${resource}`;
 
-  const exports = Object.keys(parsed.queries).map((name) => {
+  const queryExports = Object.keys(parsed.queries).map((name) => {
     return `
       export function ${name}(arg, opts = {}) {
         const searchParams = new URLSearchParams(arg);
-        searchParams.set('__query', ${JSON.stringify(name)});
+        searchParams.set('__handler', ${JSON.stringify(name)});
         return useSWR(${JSON.stringify(
           apiPage
         )} + '?' + searchParams.toString(), {
-          fetcher: (url) => fetch(url).then((res) => res.json()),
+          fetcher: __queryFetcher,
           ...opts,
         });
       }
     `;
   });
 
+  const mutationExports = Object.keys(parsed.mutations).map((name) => {
+    return `
+      export function ${name}(opts = {}) {
+        const searchParams = new URLSearchParams();
+        searchParams.set('__handler', ${JSON.stringify(name)});
+        return useSWRMutation(${JSON.stringify(
+          apiPage
+        )} + '?' + searchParams.toString(), {
+          fetcher: __mutationFetcher,
+          ...opts,
+        });
+      }
+    `;
+  });
+
+  const queryFetcher = `
+    async function __queryFetcher(url) {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error("Response with status \${response.status} is not ok.");
+      }
+      return response.json();
+    }
+  `;
+
+  const mutationFetcher = `
+    async function __mutationFetcher(url, { arg }) {
+      const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(arg),
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      })
+      if (!response.ok) {
+        throw new Error("Response with status \${response.status} is not ok.");
+      }
+      return response.json();
+    }
+  `;
+
   const concat = new ConcatSource(
     source,
     `\n/**/;`,
     'import useSWR from "swr";',
-    exports.join("\n\n")
+    'import useSWRMutation from "swr/mutation";',
+    queryFetcher,
+    mutationFetcher,
+    queryExports.join("\n\n"),
+    mutationExports.join("\n\n")
   );
 
   const { source: outputCode, map: outputSourceMap } = concat.sourceAndMap();

--- a/packages/next-swr-endpoints/src/swr-client-endpoint-loader.ts
+++ b/packages/next-swr-endpoints/src/swr-client-endpoint-loader.ts
@@ -34,7 +34,7 @@ const loader: LoaderDefinition<{
     .replace(pageExtensionsRegex, "");
   const apiPage = `${basePath}/${resource}`;
 
-  const exports = Object.keys(parsed.queries).map((name) => {
+  const queryExports = Object.keys(parsed.queries).map((name) => {
     return `
       export function ${name}(arg, opts = {}) {
         const searchParams = new URLSearchParams(arg);
@@ -49,14 +49,36 @@ const loader: LoaderDefinition<{
     `;
   });
 
+  // const mutationExports = Object.keys(parsed.mutations).map((name) => {
+  //   return `
+  //     export function ${name}(opts = {}) {
+  //       const searchParams = new URLSearchParams(arg);
+  //       searchParams.set('__query', ${JSON.stringify(name)});
+  //       return useSWRMutation(${JSON.stringify(
+  //         apiPage
+  //       )} + '?' + searchParams.toString(), {
+  //         fetcher: (url, body) =>
+  //           fetch(url, {
+  //             method: "POST",
+  //             headers: { 'Content-Type': 'application/json' },
+  //             body: JSON.stringify(body),
+  //           })
+  //           .then((res) => res.json()),
+  //         ...opts,
+  //       });
+  //     }
+  //   `;
+  // });
+
   const concat = new ConcatSource(
     source,
     `\n/**/;`,
-    'import useSWR from "swr";',
-    exports.join("\n\n")
+    'import useSWR from "swr"; import useSWRMutation from "swr/mutation";',
+    [...queryExports].join("\n\n")
   );
 
   const { source: outputCode, map: outputSourceMap } = concat.sourceAndMap();
+  console.log(outputCode);
   this.callback(null, outputCode, outputSourceMap ?? undefined, additionalData);
 };
 

--- a/packages/next-swr-endpoints/src/swr-client-endpoint-loader.ts
+++ b/packages/next-swr-endpoints/src/swr-client-endpoint-loader.ts
@@ -34,7 +34,7 @@ const loader: LoaderDefinition<{
     .replace(pageExtensionsRegex, "");
   const apiPage = `${basePath}/${resource}`;
 
-  const queryExports = Object.keys(parsed.queries).map((name) => {
+  const exports = Object.keys(parsed.queries).map((name) => {
     return `
       export function ${name}(arg, opts = {}) {
         const searchParams = new URLSearchParams(arg);
@@ -49,36 +49,14 @@ const loader: LoaderDefinition<{
     `;
   });
 
-  // const mutationExports = Object.keys(parsed.mutations).map((name) => {
-  //   return `
-  //     export function ${name}(opts = {}) {
-  //       const searchParams = new URLSearchParams(arg);
-  //       searchParams.set('__query', ${JSON.stringify(name)});
-  //       return useSWRMutation(${JSON.stringify(
-  //         apiPage
-  //       )} + '?' + searchParams.toString(), {
-  //         fetcher: (url, body) =>
-  //           fetch(url, {
-  //             method: "POST",
-  //             headers: { 'Content-Type': 'application/json' },
-  //             body: JSON.stringify(body),
-  //           })
-  //           .then((res) => res.json()),
-  //         ...opts,
-  //       });
-  //     }
-  //   `;
-  // });
-
   const concat = new ConcatSource(
     source,
     `\n/**/;`,
-    'import useSWR from "swr"; import useSWRMutation from "swr/mutation";',
-    [...queryExports].join("\n\n")
+    'import useSWR from "swr";',
+    exports.join("\n\n")
   );
 
   const { source: outputCode, map: outputSourceMap } = concat.sourceAndMap();
-  console.log(outputCode);
   this.callback(null, outputCode, outputSourceMap ?? undefined, additionalData);
 };
 

--- a/packages/next-swr-endpoints/src/swr-server-endpoint-loader.ts
+++ b/packages/next-swr-endpoints/src/swr-server-endpoint-loader.ts
@@ -1,6 +1,6 @@
 import type { LoaderDefinition } from "webpack";
 import { ReplaceSource, SourceMapSource } from "webpack-sources";
-import { parseEndpointFile, type Queries } from "./parseEndpointFile";
+import { parseEndpointFile } from "./parseEndpointFile";
 
 const loader: LoaderDefinition = function (
   content,
@@ -20,25 +20,27 @@ const loader: LoaderDefinition = function (
     source.replace(start, end, "");
   }
 
-  const queriesCode = stringifyQueries(parsed.queries);
-  const mutationsCode = stringifyQueries(parsed.mutations);
+  let queriesCode = "{";
+  for (const [name, { parserCode, callbackCode }] of Object.entries(
+    parsed.queries
+  )) {
+    queriesCode += `${JSON.stringify(
+      name
+    )}: { parser: ${parserCode}, callback: ${callbackCode} },`;
+  }
+  queriesCode += "}";
 
   const output = `
     ${source.source()}
 
     const queries = ${queriesCode};
-    const mutations = ${mutationsCode};
+    const mutations = {};
 
     export default async (req, res) => {
-      const bag = req.method === "POST" ? mutations : queries;
-      const bagName = bag === mutations ? 'mutation' : 'query';
-      const bagNamePlural = bag === mutations ? 'mutations' : 'queries';
-
-      const query = bag.get(req.query.__query);
+      const query = queries[req.query.__query];
       delete req.query.__query;
       if (!query) {
-        const available = [...bag.keys()]
-        return res.status(400).send(\`Unknown \${bagName} \${req.query.__query}. Available \${bagNamePlural}: \${available.join(", ")}\`);
+        return res.status(400).send(\`Unknown query \${req.query.__query}. Available queries: \${Object.keys(queries).join(", ")}\`);
       }
 
       const { parser, callback } = query;
@@ -58,14 +60,3 @@ const loader: LoaderDefinition = function (
 };
 
 export default loader;
-
-function stringifyQueries(queries: Queries): string {
-  const queryArrays = Object.entries(queries).map(
-    ([name, { parserCode, callbackCode }]) => {
-      return `[${JSON.stringify(
-        name
-      )}, { parser: ${parserCode}, callback: ${callbackCode} }]`;
-    }
-  );
-  return `new Map([${queryArrays.join(", ")}])`;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,14 +10,15 @@ importers:
 
   packages/example-app:
     specifiers:
+      '@playwright/test': ^1.23.2
       '@types/node': ^17.0.38
       '@types/react': ^18.0.10
       '@types/react-dom': ^18.0.5
       next: ^12.1.6
-      next-swr-endpoints: workspace:^1.0.0
+      next-swr-endpoints: workspace:*
       react: ^18.1.0
       react-dom: ^18.1.0
-      swr: ^1.3.0
+      swr: ^2.0.0-beta.6
       typescript: ^4.7.2
       zod: ^3.17.3
     dependencies:
@@ -25,9 +26,10 @@ importers:
       next-swr-endpoints: link:../next-swr-endpoints
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      swr: 1.3.0_react@18.1.0
+      swr: 2.0.0-beta.6_react@18.1.0
       zod: 3.17.3
     devDependencies:
+      '@playwright/test': 1.23.2
       '@types/node': 17.0.38
       '@types/react': 18.0.10
       '@types/react-dom': 18.0.5
@@ -45,7 +47,7 @@ importers:
       next: ^12.1.6
       react: ^18.1.0
       react-dom: ^18.1.0
-      swr: ^1.3.0
+      swr: ^2.0.0-beta.6
       tsup: ^6.0.1
       typescript: ^4.7.2
       webpack-sources: ^3.2.3
@@ -62,7 +64,7 @@ importers:
       next: 12.1.6_ef5jwxihqo6n7gxfmzogljlgcm
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      swr: 1.3.0_react@18.1.0
+      swr: 2.0.0-beta.6_react@18.1.0
       tsup: 6.0.1_typescript@4.7.2
       typescript: 4.7.2
 
@@ -223,6 +225,15 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: true
+
+  /@playwright/test/1.23.2:
+    resolution: {integrity: sha512-umaEAIwQGfbezixg3raSOraqbQGSqZP988sOaMdpA2wj3Dr6ykOscrMukyK3U6edxhpS0N8kguAFZoHwCEfTig==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@types/node': 17.0.38
+      playwright-core: 1.23.2
     dev: true
 
   /@types/eslint-scope/3.7.3:
@@ -1229,6 +1240,12 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /playwright-core/1.23.2:
+    resolution: {integrity: sha512-UGbutIr0nBALDHWW/HcXfyK6ZdmefC99Moo4qyTr89VNIkYZuDrW8Sw554FyFUamcFSdKOgDPk6ECSkofGIZjQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /postcss-load-config/3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -1427,12 +1444,14 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /swr/1.3.0_react@18.1.0:
-    resolution: {integrity: sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==}
+  /swr/2.0.0-beta.6_react@18.1.0:
+    resolution: {integrity: sha512-bZkjKiBVaZiqHpuSzWqOafihWpCd3hD/+Ju+gr8FT9++jwdCt+gGIfgC1caY6jXuKrl9kBWTYTbd1qaXPKxMog==}
+    engines: {pnpm: '7'}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.1.0
+      use-sync-external-store: 1.2.0_react@18.1.0
 
   /tapable/2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -1680,6 +1699,13 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
+
+  /use-sync-external-store/1.2.0_react@18.1.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.1.0
 
   /watchpack/2.3.1:
     resolution: {integrity: sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==}

--- a/turbo.json
+++ b/turbo.json
@@ -6,8 +6,13 @@
       "outputs": ["dist/**", ".next/**"]
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["prepare-env:test", "build"],
       "outputs": []
+    },
+    "prepare-env:test": {
+      "dependsOn": ["^prepare-env:test"],
+      "outputs": [],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
This PR introduces a new `mutation` function to allow declaring a `useSWRMutation` handler. There's a breaking change here, which changes `?__query=...` to `?__handler=...` to make sure it's not tied to the query implementation.

To make sure we don't break stuff in the future, I also added some e2e tests using Playwright.

A simple use case would be to have good lazy data fetching, for mutations specifically:

```ts
import { mutation } from 'next-swr-endpoints';
import z from 'zod';
import db from '@/src/db';

export const useCreatePost = mutation(
  z.object({ title: z.string(), contents: z.string() }),
  async ({ title, contents }) => {
    const { id } = await db.createPost({ title, contents });
    return { id };
  }
);
```

and then in the page:

```ts
import { useCreatePost } from './api/posts';

export default function Page() {
  const postCreation = useCreatePost();
  return (
    <form
      onSubmit={() => postCreation.trigger({ title: "my title", contents: "my contents" })}
    />
  );
}
```