### PR TITLE
Allow to access the incoming request through `this.request`

### DIFF
--- a/packages/example-app/pages/api/edge.swr.ts
+++ b/packages/example-app/pages/api/edge.swr.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { mutation, query } from "next-swr-endpoints";
+import { userAgent } from "next/server";
 
 export const config = { runtime: "experimental-edge" };
 
@@ -12,7 +13,11 @@ export const useRuntimeInfo = query(
 
 export const useRuntimeInfoMutation = mutation(
   z.object({ name: z.string() }),
-  async ({ name }) => {
-    return [`runtime: ${EdgeRuntime}`, `input: ${name}`];
+  async function ({ name }) {
+    return [
+      `runtime: ${EdgeRuntime}`,
+      `input: ${name}`,
+      `request browser: ${userAgent(this.request).browser?.name}`,
+    ];
   }
 );

--- a/packages/example-app/pages/api/people.swr.ts
+++ b/packages/example-app/pages/api/people.swr.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { query, mutation } from "next-swr-endpoints";
+import { userAgent } from "next/server";
 
 export const useAllPeople = query(
   z.object({ name: z.string() }),
@@ -10,7 +11,15 @@ export const useAllPeople = query(
 
 export const useListPeopleWith = mutation(
   z.object({ name: z.string() }),
-  async ({ name }) => {
-    return ["John", "Jane", "Bob", "Alice", name.trim()];
+  async function ({ name }) {
+    const agent = userAgent(this.request);
+    return [
+      agent.browser.name ?? "Unknown",
+      "John",
+      "Jane",
+      "Bob",
+      "Alice",
+      name.trim(),
+    ];
   }
 );

--- a/packages/example-app/tests/e2e/mutation.spec.ts
+++ b/packages/example-app/tests/e2e/mutation.spec.ts
@@ -2,25 +2,29 @@ import { test, expect } from "@playwright/test";
 
 test("mutation", async ({ page }) => {
   await page.goto("/form");
-  const title = page.locator("#result");
-  await expect(title).toHaveText("No data, idle.");
+  const result = page.locator("#result");
+  await expect(result).toHaveText("No data, idle.");
 
   const input = page.locator(`input[type="text"]`);
   await input.type("Gal");
   await input.press("Enter");
 
-  await expect(title.locator("li:last-child")).toHaveText("Gal");
+  const list = result.locator("li");
+  await expect(list.first()).toHaveText("Chrome");
+  await expect(list.last()).toHaveText("Gal");
 });
 
 test("edge runtime", async ({ page }) => {
   await page.goto("/form-edge");
-  const title = page.locator("#result");
-  await expect(title).toHaveText("No data, idle.");
+  const result = page.locator("#result");
+  await expect(result).toHaveText("No data, idle.");
 
   const input = page.locator(`input[type="text"]`);
   await input.type("Gal");
   await input.press("Enter");
 
-  await expect(title.locator("li").nth(0)).toHaveText("runtime: edge-runtime");
-  await expect(title.locator("li").nth(1)).toHaveText("input: Gal");
+  const list = result.locator("li");
+  await expect(list.nth(0)).toHaveText("runtime: edge-runtime");
+  await expect(list.nth(1)).toHaveText("input: Gal");
+  await expect(list.nth(2)).toHaveText("request browser: Chrome");
 });

--- a/packages/next-swr-endpoints/src/index.ts
+++ b/packages/next-swr-endpoints/src/index.ts
@@ -3,18 +3,19 @@ import type { SWRMutationResponse } from "swr/mutation";
 import type { NextConfig } from "next";
 import type { Parser } from "./parser";
 import type { Configuration } from "webpack";
+import type { HandlerCallback } from "./server";
 
-export function query<T, V>(
-  parser: Parser<T>,
-  callback: (parsed: T) => Promise<V>
-): (v: T) => SWRResponse<V> {
+export function query<Input, Output>(
+  parser: Parser<Input>,
+  callback: HandlerCallback<Input, Output>
+): (v: Input) => SWRResponse<Output> {
   throw new Error("This code path should not be reached");
 }
 
-export function mutation<T, V>(
-  parser: Parser<T>,
-  callback: (parsed: T) => Promise<V>
-): () => SWRMutationResponse<V, any, T> {
+export function mutation<Input, Output>(
+  parser: Parser<Input>,
+  callback: HandlerCallback<Input, Output>
+): () => SWRMutationResponse<Output, any, Input> {
   throw new Error("This code path should not be reached");
 }
 

--- a/packages/next-swr-endpoints/src/server.ts
+++ b/packages/next-swr-endpoints/src/server.ts
@@ -2,9 +2,18 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { type NextRequest, NextResponse } from "next/server";
 import { type Parser, parse } from "./parser";
 
+export type RequestContext = {
+  request: Request;
+};
+
+export type HandlerCallback<Input, Output> = (
+  this: RequestContext,
+  input: Input
+) => Promise<Output>;
+
 type Handler<Input, Output> = {
   parser: Parser<Input>;
-  callback: (t: Input) => Promise<Output>;
+  callback: HandlerCallback<Input, Output>;
 };
 type Handlers = Map<string, Handler<unknown, unknown>>;
 
@@ -44,7 +53,7 @@ export async function handleEdgeFunction({
     return new Response(e?.message || "Malformed input", { status: 400 });
   }
 
-  const response = await callback(data);
+  const response = await callback.call({ request }, data);
   return NextResponse.json(response);
 }
 
@@ -78,7 +87,22 @@ export async function handleNodejsFunction({
     return res.status(400).send(e?.message || "Malformed input");
   }
 
-  const response = await callback(data);
+  /**
+   * A standard {@link Request} object that represents the current {@link NextApiRequest}
+   */
+  let request: Request | null = null;
+
+  const response = await callback.call(
+    {
+      get request() {
+        if (!request) {
+          request = createStandardRequestFromNodejsRequest(req);
+        }
+        return request;
+      },
+    },
+    data
+  );
   return res.send(JSON.stringify(response));
 }
 
@@ -104,4 +128,19 @@ function getUnknownHandlerError(handlerName: string, handlers: Handlers) {
   return `Unknown handler ${handlerName}. Available handlers: ${[
     ...handlers.keys(),
   ].join(", ")}`;
+}
+
+function createStandardRequestFromNodejsRequest(req: NextApiRequest): Request {
+  const host = process.env.VERCEL_URL ?? req.headers["x-forwarded-for"];
+  return new Request(req.url ?? "/", {
+    headers: Object.entries(req.headers).flatMap(([key, values]) => {
+      if (Array.isArray(values)) {
+        return values.map((value) => [key, value]);
+      } else if (values === undefined) {
+        return [];
+      }
+      return [[key, values]];
+    }),
+    method: req.method,
+  });
 }


### PR DESCRIPTION
I would much rather to allow accessing the request through a `getRequest` function
which will feel like a magical React hook, but that will require usage of async_hooks
in Node.js, and the edge runtime does not have that

This enables using authentication using the headers. Maybe we should also allow testing
the headers with a parser?
