### PR TITLE
bugfix: favor async parsing over sync parsing

### DIFF
--- a/packages/next-swr-endpoints/src/parser.ts
+++ b/packages/next-swr-endpoints/src/parser.ts
@@ -10,6 +10,6 @@ export type Parser<Into> =
 
 export function parse<T>(parser: Parser<T>, data: unknown): Promise<T> {
   return Promise.resolve(
-    ("parse" in parser ? parser.parse : parser.parseAsync)(data)
+    ("parseAsync" in parser ? parser.parseAsync : parser.parse)(data)
   );
 }


### PR DESCRIPTION
zod will throw an error on sync parsing if a transformation returns a promise
