### PR TITLE
Fix npm packages not having the distribution files

### DIFF
--- a/.changeset/quick-rats-ring.md
+++ b/.changeset/quick-rats-ring.md
@@ -1,0 +1,6 @@
+---
+"@next-fetch/react-query": patch
+"@next-fetch/swr": patch
+---
+
+Update `package.json#files` to ensure the necessary files exist in the npm distribution

--- a/packages/@next-fetch/react-query/package.json
+++ b/packages/@next-fetch/react-query/package.json
@@ -7,11 +7,12 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "./client-loader/package.json",
-    "./client/package.json",
-    "./dist/**/*",
-    "./server-loader/package.json",
-    "./server/package.json"
+    "client-loader/package.json",
+    "client/package.json",
+    "dist/**/*",
+    "form/package.json",
+    "server-loader/package.json",
+    "server/package.json"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/@next-fetch/swr/package.json
+++ b/packages/@next-fetch/swr/package.json
@@ -7,11 +7,12 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "./client-loader/package.json",
-    "./client/package.json",
-    "./dist/**/*",
-    "./server-loader/package.json",
-    "./server/package.json"
+    "client-loader/package.json",
+    "client/package.json",
+    "dist/**/*",
+    "form/package.json",
+    "server-loader/package.json",
+    "server/package.json"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
update `package.json#files` in swr and react-query to have the files from `dist` and the sub-packages
