### PR TITLE
Restrict Form.encType

### DIFF
--- a/.changeset/neat-snakes-bow.md
+++ b/.changeset/neat-snakes-bow.md
@@ -1,0 +1,7 @@
+---
+"@next-fetch/core-plugin": patch
+"@next-fetch/react-query": patch
+"@next-fetch/swr": patch
+---
+
+Restrict FormProps to explicitly prevent users from using unsupported encTypes.

--- a/packages/@next-fetch/core-plugin/src/form.ts
+++ b/packages/@next-fetch/core-plugin/src/form.ts
@@ -15,7 +15,9 @@ export function useForm<Input, Config>(
   hook: HookWithFormSubmission<Input, Config>,
   config?: Config
 ): {
-  formProps: HTMLProps<HTMLFormElement>;
+  formProps: HTMLProps<HTMLFormElement> & {
+    encType?: "application/x-www-form-urlencoded";
+  };
 } {
   const { trigger, meta } = hook;
 

--- a/packages/@next-fetch/react-query/src/form.ts
+++ b/packages/@next-fetch/react-query/src/form.ts
@@ -22,7 +22,9 @@ export function useForm<Data, Error, Input, Context>(
   hook: HookWithFormSubmission<Data, Error, Input, Context>,
   config?: UseMutationOptions<Data, Error, Input, Context>
 ): {
-  formProps: HTMLProps<HTMLFormElement>;
+  formProps: HTMLProps<HTMLFormElement> & {
+    encType?: "application/x-www-form-urlencoded";
+  };
 } {
   return useForm_({ meta: hook.meta, trigger: hook.mutate }, config);
 }
@@ -40,6 +42,7 @@ export function Form<Data, Error, Input, Context>({
   React.PropsWithChildren<{
     mutation: HookWithFormSubmission<Data, Error, Input, Context>;
     mutationConfig?: UseMutationOptions<Data, Error, Input, Context>;
+    encType?: "application/x-www-form-urlencoded";
   }>) {
   const { formProps } = useForm(mutation, mutationConfig);
   return createElement("form", { ...formProps, ...props }, props.children);

--- a/packages/@next-fetch/swr/src/form.ts
+++ b/packages/@next-fetch/swr/src/form.ts
@@ -22,7 +22,9 @@ export function useForm<Data, Error>(
   hook: HookWithFormSubmission<Data, Error>,
   config?: SWRMutationConfiguration<Data, Error>
 ): {
-  formProps: HTMLProps<HTMLFormElement>;
+  formProps: HTMLProps<HTMLFormElement> & {
+    encType?: "application/x-www-form-urlencoded";
+  };
 } {
   return useForm_(hook, config);
 }
@@ -40,6 +42,7 @@ export function Form<Data, Error>({
   React.PropsWithChildren<{
     mutation: HookWithFormSubmission<Data, Error>;
     mutationConfig?: SWRMutationConfiguration<Data, Error>;
+    encType?: "application/x-www-form-urlencoded";
   }>) {
   const { formProps } = useForm(mutation, mutationConfig);
   return createElement("form", { ...formProps, ...props }, props.children);


### PR DESCRIPTION
This PR prevents users from adding another `Form.encType` like `application/x-www-form-urlencoded`. This prevents breaking changes in the future.

Related: #36
